### PR TITLE
Added serverlessdays amsterdam event on 8th of May

### DIFF
--- a/eventsData.json
+++ b/eventsData.json
@@ -102,6 +102,16 @@
       "language": "English"
     },
     {
+      "event": "ServerlessDays Amsterdam - virtual conference",
+      "organizer": "ServerlessDays Amsterdam",
+      "starttime": 1588921200,
+      "endtime": 1588951800,
+      "location": "Online",
+      "description": "ServerlessDays Amsterdam is a developer-oriented conference about serverless technologies.",
+      "url": "https://serverlessdays.nl/",
+      "language": "English"
+    },
+    {
       "event": "Nordic Serverless Chaos Engineering Special",
       "organizer": "Nordic Serverless",
       "starttime": 1589385600,


### PR DESCRIPTION
I've added the ServerlessDays Amsterdam conference on 8th of May. I've linked to the conference page where you can register for a free ticket and see the agenda of the event. 