### PR TITLE
added timezone support in the 'view event' screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gatsby-plugin-react-helmet": "^3.1.21",
     "gatsby-plugin-sass": "^2.1.27",
     "match-sorter": "^4.1.0",
+    "moment-timezone": "^0.5.28",
     "namor": "^2.0.2",
     "node-sass": "^4.13.1",
     "react": "^16.12.0",

--- a/src/components/Events.js
+++ b/src/components/Events.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import eventsData from "../../eventsData.json"
+import moment from 'moment-timezone';
 
 const Events = props => (
   <nav id="events">
@@ -16,7 +17,7 @@ const Events = props => (
                 <tr>
                   <th>Event</th>
                   <th>Organizer</th>
-                  <th>Date and time UTC</th>
+                  <th>Date and time UTC {new Date().getTimezoneOffset() / 60}</th>
                   <th>Location</th>
                   <th>Description</th>
                   <th>Language</th>
@@ -25,10 +26,12 @@ const Events = props => (
               </thead>
               <tbody>
                 {eventsData.content.map((data, index) => {
+                  var usertz = moment.tz.guess();
+
                   if (Date.now()/1000 < data.starttime) {
                     var utmData = '?utm_source=serverlessevents&utm_medium=site&utm_campaign=serverlessevents&utm_content=serverlessevents'
                     var formattedStartTime = Intl.DateTimeFormat('en-US',{
-                      timeZone: "UTC",
+                      timeZone: usertz,
                       year: "numeric",
                       month: "short",
                       day: "2-digit",


### PR DESCRIPTION
- The date and time in the 'view event' screen are now shown based on the user's local timezone as retrieved from the browser.
- The table row of the agenda shows the timezone offset from UTC.